### PR TITLE
Linux compatibility

### DIFF
--- a/SCEPman/Private/app-service.ps1
+++ b/SCEPman/Private/app-service.ps1
@@ -151,7 +151,7 @@ function GetAppServiceHostNames ($SCEPmanResourceGroup, $AppServiceName, $Deploy
 
 function CreateSCEPmanDeploymentSlot ($SCEPmanResourceGroup, $SCEPmanAppServiceName, $DeploymentSlotName) {
   $existingHostnameConfiguration = ReadAppSetting -AppServiceName $SCEPmanAppServiceName -ResourceGroup $SCEPmanResourceGroup -SettingName "AppConfig:AuthConfig:ManagedIdentityEnabledForWebsiteHostname"
-  
+
   if([string]::IsNullOrEmpty($existingHostnameConfiguration)) {
     SetAppSettings -AppServiceName $SCEPmanAppServiceName -ResourceGroup $SCEPmanResourceGroup -Settings @(@{name="AppConfig:AuthConfig:ManagedIdentityEnabledForWebsiteHostname"; value=$SCEPmanSlotHostName})
     Write-Information "Specified Production Slot Activation as such via AppConfig:AuthConfig:ManagedIdentityEnabledForWebsiteHostname"
@@ -359,6 +359,6 @@ function ReadAppSetting($AppServiceName, $ResourceGroup, $SettingName, $Slot = $
   if ($null -ne $Slot) {
     $azCommand += @("--slot", $Slot)
   }
-  
+
   return ExecuteAzCommandRobustly -callAzNatively -azCommand $azCommand -noSecretLeakageWarning
 }

--- a/SCEPman/Private/az-commands.ps1
+++ b/SCEPman/Private/az-commands.ps1
@@ -256,3 +256,16 @@ function HashTable2AzJson($psHashTable) {
     }
       return $output
 }
+
+function AppSettingsHashTable2AzJson($psHashTable, $convertForLinux) {
+    if ($convertForLinux) {
+        $escapedpsHashTable = @{}
+        foreach ($key in $psHashTable.Keys) {
+            $escapedpsHashTable.Add($key.Replace(":","__"), $psHashTable[$key])
+        }
+    } else {
+        $escapedpsHashTable = $psHashTable
+    }
+
+    return HashTable2AzJson -psHashTable $escapedpsHashTable
+}

--- a/SCEPman/Private/key-vault.ps1
+++ b/SCEPman/Private/key-vault.ps1
@@ -20,7 +20,7 @@ function FindConfiguredKeyVault ($SCEPmanResourceGroup, $SCEPmanAppServiceName) 
 
 function FindConfiguredKeyVaultUrl ($SCEPmanResourceGroup, $SCEPmanAppServiceName) {
   [uri]$configuredKeyVaultURL = ReadAppSetting -ResourceGroup $SCEPmanResourceGroup -AppServiceName $SCEPmanAppServiceName -SettingName "AppConfig:KeyVaultConfig:KeyVaultURL"
-  
+
   Write-Verbose "Configured Key Vault URL is $configuredKeyVaultURL"
 
   return $configuredKeyVaultURL

--- a/SCEPman/Private/key-vault.ps1
+++ b/SCEPman/Private/key-vault.ps1
@@ -19,8 +19,8 @@ function FindConfiguredKeyVault ($SCEPmanResourceGroup, $SCEPmanAppServiceName) 
 }
 
 function FindConfiguredKeyVaultUrl ($SCEPmanResourceGroup, $SCEPmanAppServiceName) {
-  [uri]$configuredKeyVaultURL = ExecuteAzCommandRobustly -azCommand @("webapp", "config", "appsettings", "list", "--name", $SCEPmanAppServiceName, "--resource-group", $SCEPmanResourceGroup, 
-    "--query", "[?name=='AppConfig:KeyVaultConfig:KeyVaultURL'].value | [0]", "--output", "tsv") -callAzNatively -noSecretLeakageWarning
+  [uri]$configuredKeyVaultURL = ReadAppSetting -ResourceGroup $SCEPmanResourceGroup -AppServiceName $SCEPmanAppServiceName -SettingName "AppConfig:KeyVaultConfig:KeyVaultURL"
+  
   Write-Verbose "Configured Key Vault URL is $configuredKeyVaultURL"
 
   return $configuredKeyVaultURL

--- a/SCEPman/Private/storage-account.ps1
+++ b/SCEPman/Private/storage-account.ps1
@@ -87,6 +87,7 @@ function SetTableStorageEndpointsInScAndCmAppSettings ($SubscriptionId, $SCEPman
     $existingTableStorageEndpointSettingSc = GetSCEPmanStorageAccountConfig -ResourceGroup $SCEPmanResourceGroup -AppServiceName $SCEPmanAppServiceName -DeploymentSlotName $DeploymentSlotName
     if(![string]::IsNullOrEmpty($existingTableStorageEndpointSettingSc)) {
         $storageAccountTableEndpoint = $existingTableStorageEndpointSettingSc.Trim('"')
+        Write-Verbose "Found existing storage account table endpoint in SCEPman's app settings"
     }
 
     if ($null -ne $CertMasterAppServiceName) {
@@ -99,6 +100,7 @@ function SetTableStorageEndpointsInScAndCmAppSettings ($SubscriptionId, $SCEPman
 
         if([string]::IsNullOrEmpty($storageAccountTableEndpoint) -and ![string]::IsNullOrEmpty($existingTableStorageEndpointSettingCm)) {
             $storageAccountTableEndpoint = $existingTableStorageEndpointSettingCm.Trim('"')
+            Write-Verbose "Found existing storage account table endpoint in CertMaster's app settings"
         }
     }
 

--- a/SCEPman/Private/storage-account.ps1
+++ b/SCEPman/Private/storage-account.ps1
@@ -84,7 +84,7 @@ function GetSCEPmanStorageAccountConfig( $SCEPmanResourceGroup, $SCEPmanAppServi
 
 function SetTableStorageEndpointsInScAndCmAppSettings ($SubscriptionId, $SCEPmanResourceGroup, $SCEPmanAppServiceName, $CertMasterResourceGroup, $CertMasterAppServiceName, $servicePrincipals, $DeploymentSlotName, $DeploymentSlots) {
     $storageAccountTableEndpoint = $null
-    $existingTableStorageEndpointSettingSc = GetSCEPmanStorageAccountConfig -ResourceGroup $SCEPmanResourceGroup -AppServiceName $SCEPmanAppServiceName -DeploymentSlotName $DeploymentSlotName
+    $existingTableStorageEndpointSettingSc = GetSCEPmanStorageAccountConfig -SCEPmanResourceGroup $SCEPmanResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -DeploymentSlotName $DeploymentSlotName
     if(![string]::IsNullOrEmpty($existingTableStorageEndpointSettingSc)) {
         $storageAccountTableEndpoint = $existingTableStorageEndpointSettingSc.Trim('"')
         Write-Verbose "Found existing storage account table endpoint in SCEPman's app settings"
@@ -128,7 +128,8 @@ function SetTableStorageEndpointsInScAndCmAppSettings ($SubscriptionId, $SCEPman
         $storageSettingForCm = @(
             @{name='AppConfig:AzureStorage:TableStorageEndpoint'; value=$storageAccountTableEndpoint}
         )
-        SetAppSettings -AppServiceName $CertMasterAppServiceName -ResourceGroup $CertMasterResourceGroup -Settings  $storageSettingForCm
+        Write-Debug "Setting storage account table endpoint in CertMaster"
+        SetAppSettings -AppServiceName $CertMasterAppServiceName -ResourceGroup $CertMasterResourceGroup -Settings $storageSettingForCm
     }
 
     $storageSettingForSm = @(

--- a/SCEPman/Public/New-IntermediateCA.ps1
+++ b/SCEPman/Public/New-IntermediateCA.ps1
@@ -62,7 +62,7 @@ function New-IntermediateCA
 
   $vaultUrl = FindConfiguredKeyVaultUrl -SCEPmanAppServiceName $SCEPmanAppServiceName -SCEPmanResourceGroup $SCEPmanResourceGroup
 
-  $certificateName = az webapp config appsettings list --name $SCEPmanAppServiceName --resource-group $SCEPmanResourceGroup --query "[?name=='AppConfig:KeyVaultConfig:RootCertificateConfig:CertificateName'].value | [0]" --output tsv
+  $certificateName = ReadAppSetting -ResourceGroup $SCEPmanResourceGroup -AppServiceName $SCEPmanAppServiceName -SettingName "AppConfig:KeyVaultConfig:RootCertificateConfig:CertificateName"
   Write-Information "Found Key Vault configuration with URL $vaultUrl and certificate name $certificateName."
 
   $policy = $global:subCaPolicy

--- a/SCEPman/Public/Sync-IntuneCertificate.ps1
+++ b/SCEPman/Public/Sync-IntuneCertificate.ps1
@@ -51,9 +51,9 @@ function Sync-IntuneCertificate
     Write-Verbose "CertMaster web app url is $CertMasterBaseURL"
 
     Write-Information "Getting App ID of Certificate Master"
-    $CertMasterAppId = ExecuteAzCommandRobustly -azCommand ("az webapp config appsettings list --name $CertMasterAppServiceName --resource-group $CertMasterResourceGroup --query ""[?name=='AppConfig:AuthConfig:HomeApplicationId'].value | [0]"" --output tsv")
+    $CertMasterAppId = ReadAppSetting -ResourceGroup $CertMasterResourceGroup -AppServiceName $CertMasterAppServiceName -SettingName "AppConfig:AuthConfig:HomeApplicationId"
     if ([String]::IsNullOrWhiteSpace($CertMasterAppId)) {
-      $CertMasterAppId = ExecuteAzCommandRobustly -azCommand ("az webapp config appsettings list --name $CertMasterAppServiceName --resource-group $CertMasterResourceGroup --query ""[?name=='AppConfig:AuthConfig:ApplicationId'].value | [0]"" --output tsv")
+      $CertMasterAppId = ReadAppSetting -ResourceGroup $CertMasterResourceGroup -AppServiceName $CertMasterAppServiceName -SettingName "AppConfig:AuthConfig:ApplicationId"
       if ([String]::IsNullOrWhiteSpace($CertMasterAppId)) {
         Write-Error "Could not find App ID of Certificate Master"
         throw "Could not find App ID of Certificate Master"


### PR DESCRIPTION
Currently, the CMDlets expect the App Service Plan to be Windows. This PR is to make it compatible with Linux.

The primary issue is that Windows expects settings in the AppConfig:SettingName format, while Linux expects AppConfig__SettingName.