### PR TITLE
#108 Add additional error case for existing permission assignment

### DIFF
--- a/SCEPman/Private/az-commands.ps1
+++ b/SCEPman/Private/az-commands.ps1
@@ -40,7 +40,7 @@ function CheckAzOutput($azOutput, $fThrowOnError, $noSecretLeakageWarning = $fal
     foreach ($outputElement in $azOutput) {
         if ($null -ne $outputElement) {
             if ($outputElement.GetType() -eq [System.Management.Automation.ErrorRecord]) {
-                if ($outputElement.ToString().Contains("Permission being assigned already exists on the object")) {
+                if ($outputElement.ToString().Contains("Permission being assigned already exists on the object") -or $outputElement.ToString().Contains("RoleAssignmentExists")) {
                     Write-Information "Permission is already assigned when executing $azCommand"
                     Write-Output $PERMISSION_ALREADY_ASSIGNED
                 }


### PR DESCRIPTION
Fix uncaught az error if we get an unknown error message for existing role assignments