### PR TITLE
#136 Always add fine grained roles

### DIFF
--- a/SCEPman/Private/appregistrations.ps1
+++ b/SCEPman/Private/appregistrations.ps1
@@ -112,18 +112,10 @@ function CreateSCEPmanAppRegistration ($AzureADAppNameForSCEPman, $CertMasterSer
   return $appregsc
 }
 
-function CreateCertMasterAppRegistration ($AzureADAppNameForCertMaster, $CertMasterBaseURLs, $SkipAutoGrant = $false, $AddAdditionalAppRoles = $false) {
+function CreateCertMasterAppRegistration ($AzureADAppNameForCertMaster, $CertMasterBaseURLs, $SkipAutoGrant = $false) {
 
   Write-Information "Getting Azure AD app registration for CertMaster"
   ### CertMaster App Registration
-
-  if ($AddAdditionalAppRoles) {
-    Write-Verbose "Adding additional app roles to CertMaster App Registration"
-    $AppRoleAssignments = $CertmasterManifest + $CertmasterAdditionalManifest
-  } else {
-    $AppRoleAssignments = $CertmasterManifest
-  }
-
   $signInUrlArray = $CertMasterBaseURLs | ForEach-Object { "$_/signin-oidc" }
   $spaceSeparatedSignInUrls = $signInUrlArray -join " "
 

--- a/SCEPman/Private/appregistrations.ps1
+++ b/SCEPman/Private/appregistrations.ps1
@@ -120,7 +120,7 @@ function CreateCertMasterAppRegistration ($AzureADAppNameForCertMaster, $CertMas
   $spaceSeparatedSignInUrls = $signInUrlArray -join " "
 
   # Register CertMaster App
-  $appregcm = RegisterAzureADApp -name $AzureADAppNameForCertMaster -appRoleAssignments $AppRoleAssignments -replyUrls $spaceSeparatedSignInUrls -hideApp $false -homepage $CertMasterBaseURLs[0] -EnableIdToken $true
+  $appregcm = RegisterAzureADApp -name $AzureADAppNameForCertMaster -appRoleAssignments $CertmasterManifest -replyUrls $spaceSeparatedSignInUrls -hideApp $false -homepage $CertMasterBaseURLs[0] -EnableIdToken $true
   $null = CreateServicePrincipal -appId $($appregcm.appId)
 
   # Expose CertMaster API

--- a/SCEPman/Private/constants.ps1
+++ b/SCEPman/Private/constants.ps1
@@ -134,10 +134,8 @@ New-Variable -Name "CertmasterManifest" -Scope "Script" -Option ReadOnly -Value 
   'displayName' = 'Request Server'
   'isEnabled' = $true
   'value' = 'Request.Server'
-})
-
-# To-be JSON defining additional, non-default, App Roles that User can have when authenticating against CertMaster
-New-Variable -Name "CertmasterAdditionalManifest" -Scope "Script" -Option ReadOnly -Value @(@{
+},
+@{
   'allowedMemberTypes' = @( 'User' )
   'description' = "Request certificates of all types using CSR"
   'displayName' = 'Request All (CSR)'

--- a/SCEPman/Public/Complete-SCEPmanInstallation.ps1
+++ b/SCEPman/Public/Complete-SCEPmanInstallation.ps1
@@ -23,9 +23,6 @@
  .Parameter SubscriptionId
   The ID of the Subscription where SCEPman is installed. Can be omitted if it is pre-selected in az already or use the SearchAllSubscriptions flag to search all accessible subscriptions
 
- .Parameter AddAdditionalCertMasterAppRoles
-  Set this flag to add additional app roles to the SCEPman Certificate Master App Service.
-
  .PARAMETER SkipAppRoleAssignments
   Set this flag to skip the app role assignments. This is useful if you don't have Global Administrator permissions. You will have to assign the app roles manually later, but the CMDlet will show which az commands to execute manually for the assignment.
 
@@ -60,7 +57,6 @@ function Complete-SCEPmanInstallation
         [switch]$SearchAllSubscriptions,
         $DeploymentSlotName,
         $SubscriptionId,
-        [switch]$AddAdditionalCertMasterAppRoles,
         [switch]$SkipAppRoleAssignments,
         [switch]$SkipCertificateMaster,
         $AzureADAppNameForSCEPman = 'SCEPman-api',
@@ -248,7 +244,7 @@ function Complete-SCEPmanInstallation
             $CertMasterBaseURL = $CertMasterBaseURLs[0]
             Write-Verbose "CertMaster web app url are $CertMasterBaseURL"
 
-            $appregcm = CreateCertMasterAppRegistration -AzureADAppNameForCertMaster $AzureADAppNameForCertMaster -CertMasterBaseURLs $CertMasterBaseURLs -SkipAutoGrant $SkipAppRoleAssignments -AddAdditionalAppRoles $AddAdditionalCertMasterAppRoles
+            $appregcm = CreateCertMasterAppRegistration -AzureADAppNameForCertMaster $AzureADAppNameForCertMaster -CertMasterBaseURLs $CertMasterBaseURLs -SkipAutoGrant $SkipAppRoleAssignments
         }
     }
 


### PR DESCRIPTION
Remove the parameter in `Complete-SCEPmanInstallation` to add additional app roles for Certificate Master and always add them.