### PR TITLE
Scope Azure Resource Graph queries to a specific subscription

### DIFF
--- a/SCEPman/Private/app-service.ps1
+++ b/SCEPman/Private/app-service.ps1
@@ -1,11 +1,11 @@
-function GetCertMasterAppServiceName ($CertMasterResourceGroup, $SCEPmanAppServiceName) {
+function GetCertMasterAppServiceName ($CertMasterResourceGroup, $SCEPmanAppServiceName, $SubscriptionId) {
   #       Criteria:
   #       - Configuration value AppConfig:SCEPman:URL must be present, then it must be a CertMaster
   #       - In a default installation, the URL must contain SCEPman's app service name. We require this.
 
   $strangeCertMasterFound = $false
 
-  $rgwebapps = Invoke-Az -azCommand @("graph", "query", "-q", "Resources | where type == 'microsoft.web/sites' and resourceGroup == '$CertMasterResourceGroup' and name !~ '$SCEPmanAppServiceName' | project name") | Convert-LinesToObject
+  $rgwebapps = Invoke-Az -azCommand @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.web/sites' and resourceGroup == '$CertMasterResourceGroup' and name !~ '$SCEPmanAppServiceName' | project name") | Convert-LinesToObject
   Write-Information "$($rgwebapps.count) web apps found in the resource group $CertMasterResourceGroup (excluding SCEPman). We are finding if the CertMaster app is already created"
   if($rgwebapps.count -gt 0) {
     ForEach($potentialcmwebapp in $rgwebapps.data) {
@@ -90,19 +90,20 @@ function New-CertMasterAppService {
     [Parameter(Mandatory=$true)]    [string]$CertMasterResourceGroup,
     [Parameter(Mandatory=$false)][AllowEmptyString()]    [string]$CertMasterAppServiceName,
     [Parameter(Mandatory=$false)]    [string]$DeploymentSlotName,
-    [Parameter(Mandatory=$false)]    [string]$UpdateChannel = "prod"
+    [Parameter(Mandatory=$false)]    [string]$UpdateChannel = "prod",
+    [Parameter(Mandatory=$true)]    [string]$SubscriptionId
   )
 
   if ([String]::IsNullOrWhiteSpace($CertMasterAppServiceName)) {
-    $CertMasterAppServiceName = GetCertMasterAppServiceName -CertMasterResourceGroup $CertMasterResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName
+    $CertMasterAppServiceName = GetCertMasterAppServiceName -CertMasterResourceGroup $CertMasterResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $SubscriptionId
     $ShallCreateCertMasterAppService = [String]::IsNullOrWhiteSpace($CertMasterAppServiceName)
   } else {
     # Check whether a cert master app service with the passed in name exists
-    $CertMasterWebApps = Invoke-Az -azCommand @("graph", "query", "-q", "Resources | where type == 'microsoft.web/sites' and resourceGroup == '$CertMasterResourceGroup' and name =~ '$CertMasterAppServiceName' | project name") | Convert-LinesToObject
+    $CertMasterWebApps = Invoke-Az -azCommand @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.web/sites' and resourceGroup == '$CertMasterResourceGroup' and name =~ '$CertMasterAppServiceName' | project name") | Convert-LinesToObject
     $ShallCreateCertMasterAppService = 0 -eq $CertMasterWebApps.count
   }
 
-  $scwebapp = Invoke-Az -azCommand @("graph", "query", "-q", "Resources | where type == 'microsoft.web/sites' and resourceGroup == '$SCEPmanResourceGroup' and name =~ '$SCEPmanAppServiceName'") | Convert-LinesToObject
+  $scwebapp = Invoke-Az -azCommand @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.web/sites' and resourceGroup == '$SCEPmanResourceGroup' and name =~ '$SCEPmanAppServiceName'") | Convert-LinesToObject
 
   if([String]::IsNullOrWhiteSpace($CertMasterAppServiceName)) {
     $CertMasterAppServiceName = $scwebapp.data.name
@@ -133,7 +134,7 @@ function New-CertMasterAppService {
       # Do all the configuration that the ARM template does normally
       $SCEPmanHostname = $scwebapp.data.properties.defaultHostName
       if (-not [String]::IsNullOrWhiteSpace($DeploymentSlotName)) {
-        $selectedSlot = Invoke-Az -azCommand @("graph", "query", "-q", "Resources | where type == 'microsoft.web/sites/slots' and resourceGroup == '$SCEPmanResourceGroup' and name =~ '$SCEPmanAppServiceName/$DeploymentSlotName'") | Convert-LinesToObject
+        $selectedSlot = Invoke-Az -azCommand @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.web/sites/slots' and resourceGroup == '$SCEPmanResourceGroup' and name =~ '$SCEPmanAppServiceName/$DeploymentSlotName'") | Convert-LinesToObject
         $SCEPmanHostname = $selectedSlot.data.properties.defaultHostName
       }
       $CertmasterAppSettingsTable = @{

--- a/SCEPman/Private/key-vault.ps1
+++ b/SCEPman/Private/key-vault.ps1
@@ -18,10 +18,10 @@ function AddSCEPmanPermissionsToKeyVault ($KeyVault, $PrincipalId) {
   }
 }
 
-function FindConfiguredKeyVault ($SCEPmanResourceGroup, $SCEPmanAppServiceName) {
+function FindConfiguredKeyVault ($SCEPmanResourceGroup, $SCEPmanAppServiceName, $SubscriptionId) {
   [uri]$configuredKeyVaultURL = FindConfiguredKeyVaultUrl -SCEPmanResourceGroup $SCEPmanResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName
 
-  $keyVault = Invoke-az -azCommand @("graph", "query", "-q", "Resources | where type == 'microsoft.keyvault/vaults' and properties.vaultUri startswith '$configuredKeyVaultURL' | project name,subscriptionId,properties.enableRbacAuthorization,id") | Convert-LinesToObject
+  $keyVault = Invoke-az -azCommand @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.keyvault/vaults' and properties.vaultUri startswith '$configuredKeyVaultURL' | project name,subscriptionId,properties.enableRbacAuthorization,id") | Convert-LinesToObject
 
   if($keyVault.count -eq 1) {
     return $keyVault.data

--- a/SCEPman/Private/log-analytics.ps1
+++ b/SCEPman/Private/log-analytics.ps1
@@ -1,12 +1,12 @@
-function GetLogAnalyticsWorkspace ($ResourceGroup, $WorkspaceId) {
+function GetLogAnalyticsWorkspace ($ResourceGroup, $WorkspaceId, $SubscriptionId) {
     # Try to find by workspace id
     if($null -ne $WorkspaceId) {
-        $workspaces = Invoke-Az @("graph", "query", "-q", "Resources | where type == 'microsoft.operationalinsights/workspaces' and properties.customerId == '$WorkspaceId' | project name, workspaceId = properties.customerId, location, resourceGroup") | Convert-LinesToObject
+        $workspaces = Invoke-Az @("graph", "query","--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.operationalinsights/workspaces' and properties.customerId == '$WorkspaceId' | project name, workspaceId = properties.customerId, location, resourceGroup") | Convert-LinesToObject
     }
 
     # Try to find by resource group
     if($null -eq $workspaces -or $workspaces.count -eq 0) {
-        $workspaces = Invoke-Az @("graph", "query", "-q", "Resources | where type == 'microsoft.operationalinsights/workspaces' and resourceGroup == '$ResourceGroup' | project name, workspaceId = properties.customerId, location, resourceGroup") | Convert-LinesToObject
+        $workspaces = Invoke-Az @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.operationalinsights/workspaces' and resourceGroup == '$ResourceGroup' | project name, workspaceId = properties.customerId, location, resourceGroup") | Convert-LinesToObject
     }
 
     if($workspaces.count -eq 1) {
@@ -36,17 +36,19 @@ function GetDataCollectionRule {
         [Parameter(Mandatory, ParameterSetName = "ByResourceGroup")]
         [string]$ResourceGroup,
         [Parameter(Mandatory, ParameterSetName = "ByDcrId")]
-        [string]$DcrId
+        [string]$DcrId,
+        [Parameter(Mandatory)]
+        [string]$SubscriptionId
     )
 
     if($PSCmdlet.ParameterSetName -eq 'ByDcrId') {
         Write-Verbose "Looking for data collection rule with id $DcrId"
-        $dataCollectionRule = Invoke-Az @("graph", "query", "-q", "Resources | where type == 'microsoft.insights/datacollectionrules' and properties.immutableId == '$DcrId' | project id, name, location, resourceGroup, endpoints = properties.endpoints, immutableId = properties.immutableId") | Convert-LinesToObject
+        $dataCollectionRule = Invoke-Az @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.insights/datacollectionrules' and properties.immutableId == '$DcrId' | project id, name, location, resourceGroup, endpoints = properties.endpoints, immutableId = properties.immutableId") | Convert-LinesToObject
     }
 
     if($PSCmdlet.ParameterSetName -eq 'ByResourceGroup') {
         Write-Verbose "Looking for data collection rules in the resource group $ResourceGroup"
-        $dataCollectionRule = Invoke-Az @("graph", "query", "-q", "Resources | where type == 'microsoft.insights/datacollectionrules' and resourceGroup == '$ResourceGroup' | project id, name, location, resourceGroup, endpoints = properties.endpoints, immutableId = properties.immutableId") | Convert-LinesToObject
+        $dataCollectionRule = Invoke-Az @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.insights/datacollectionrules' and resourceGroup == '$ResourceGroup' | project id, name, location, resourceGroup, endpoints = properties.endpoints, immutableId = properties.immutableId") | Convert-LinesToObject
 
         if($dataCollectionRule.count -gt 1) {
             Write-Information "Found data collection rules:"
@@ -321,7 +323,7 @@ function Set-LoggingConfigInAppSettings {
     if (-not [string]::IsNullOrEmpty($existingWorkspaceId) -and [string]::IsNullOrEmpty($existingDcrRuleId)) {
         Write-Information "Missing Log Ingestion API configuration detected while using existing log analytics workspace. Proceeding to configure Log Ingestion API resources."
         # Get LAW resource details
-        $workspaceAccount = GetLogAnalyticsWorkspace -ResourceGroup $ResourceGroup -WorkspaceId $existingWorkspaceId
+        $workspaceAccount = GetLogAnalyticsWorkspace -ResourceGroup $ResourceGroup -WorkspaceId $existingWorkspaceId -SubscriptionId $SubscriptionId
 
         if ($null -eq $workspaceAccount) {
             Write-Warning "Could not find the log analytics workspace with id $existingWorkspaceId. Please check if the workspace still exists or if the app setting is configured correctly. Skipping Log Ingestion API configuration."
@@ -333,7 +335,7 @@ function Set-LoggingConfigInAppSettings {
     } elseif (-not [string]::IsNullOrEmpty($existingDcrRuleId)) {
         Write-Information "Existing Log Ingestion API configuration detected. Validate permissions"
         # Get DCR details
-        $dcrDetails = GetDataCollectionRule -DcrId $existingDcrRuleId
+        $dcrDetails = GetDataCollectionRule -DcrId $existingDcrRuleId -SubscriptionId $SubscriptionId
 
         if ($null -eq $dcrDetails) {
             Write-Warning "Unable to find existing Data Collection Rule with id $existingDcrRuleId"
@@ -343,7 +345,7 @@ function Set-LoggingConfigInAppSettings {
         Write-Information "Neither existing log analytics workspace nor existing Log Ingestion API configuration detected. Check if we have a log analytics workspace in the resource group."
 
         # Try to find LAW in our resource group
-        $workspaceAccount = GetLogAnalyticsWorkspace -ResourceGroup $ResourceGroup
+        $workspaceAccount = GetLogAnalyticsWorkspace -ResourceGroup $ResourceGroup -SubscriptionId $SubscriptionId
 
         if ($null -eq $workspaceAccount) {
             Write-Information "No existing log analytics workspace found. Skipping logging configuration."

--- a/SCEPman/Private/storage-account.ps1
+++ b/SCEPman/Private/storage-account.ps1
@@ -1,6 +1,6 @@
 
-function VerifyStorageAccountDoesNotExist ($ResourceGroup) {
-    $storageAccounts = Invoke-Az -azCommand @("graph", "query", "-q", "Resources | where type == 'microsoft.storage/storageaccounts' and resourceGroup == '$ResourceGroup' | project name, resourceGroup, primaryEndpoints = properties.primaryEndpoints, subscriptionId, location") | Convert-LinesToObject
+function VerifyStorageAccountDoesNotExist ($ResourceGroup, $SubscriptionId) {
+    $storageAccounts = Invoke-Az -azCommand @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.storage/storageaccounts' and resourceGroup == '$ResourceGroup' | project name, resourceGroup, primaryEndpoints = properties.primaryEndpoints, subscriptionId, location") | Convert-LinesToObject
     if($storageAccounts.count -gt 0) {
         $potentialStorageAccountName = Read-Host "We have found one or more existing storage accounts in the resource group $ResourceGroup. Please hit enter now if you still want to create a new storage account or enter the name of the storage account you would like to use, and then hit enter"
         if(!$potentialStorageAccountName) {
@@ -22,8 +22,8 @@ function VerifyStorageAccountDoesNotExist ($ResourceGroup) {
     }
 }
 
-function GetExistingStorageAccount ($dataTableEndpoint) {
-    $storageAccounts = Invoke-Az -azCommand @("graph", "query", "-q", "Resources | where type == 'microsoft.storage/storageaccounts' and properties.primaryEndpoints.table startswith '$($dataTableEndpoint.TrimEnd('/'))' | project name, resourceGroup, primaryEndpoints = properties.primaryEndpoints, subscriptionId, location") | Convert-LinesToObject
+function GetExistingStorageAccount ($dataTableEndpoint, $SubscriptionId) {
+    $storageAccounts = Invoke-Az -azCommand @("graph", "query", "--subscriptions", $SubscriptionId, "-q", "Resources | where type == 'microsoft.storage/storageaccounts' and properties.primaryEndpoints.table startswith '$($dataTableEndpoint.TrimEnd('/'))' | project name, resourceGroup, primaryEndpoints = properties.primaryEndpoints, subscriptionId, location") | Convert-LinesToObject
     Write-Debug "When searching for Storage Account $dataTableEndpoint, $($storageAccounts.count) accounts look like the searched one"
     $storageAccounts = $storageAccounts.data | Where-Object { $_.primaryEndpoints.table.TrimEnd('/') -eq $dataTableEndpoint.TrimEnd('/')}
     if ($null -ne $storageAccounts.count) { # In PS 7 (?), $storageAccounts is an array; In PS 5, $null has a count property with value 0
@@ -53,7 +53,7 @@ function SetStorageAccountPermissions ($SubscriptionId, $ScStorageAccount, $serv
 }
 
 function CreateScStorageAccount ($SubscriptionId, $ResourceGroup, $servicePrincipals) {
-    $ScStorageAccount = VerifyStorageAccountDoesNotExist -ResourceGroup $ResourceGroup
+    $ScStorageAccount = VerifyStorageAccountDoesNotExist -ResourceGroup $ResourceGroup -SubscriptionId $SubscriptionId
     if($null -eq $ScStorageAccount) {
         Write-Information 'Storage account not found. We will create one now'
         $storageAccountName = $ResourceGroup.ToLower() -replace '[^a-z0-9]',''
@@ -136,7 +136,7 @@ function Set-TableStorageEndpointsInScAndCmAppSettings {
     } else {
         Write-Verbose 'Storage account table endpoint found in app settings'
 
-        $ScStorageAccount = GetExistingStorageAccount -dataTableEndpoint $storageAccountTableEndpoint
+        $ScStorageAccount = GetExistingStorageAccount -dataTableEndpoint $storageAccountTableEndpoint -SubscriptionId $SubscriptionId
         if ($null -eq $ScStorageAccount) {
             Write-Warning "Data Table endpoint $storageAccountTableEndpoint is configured in either SCEPman or Certificate Master, but no such storage account could be found"
 

--- a/SCEPman/Private/subscriptions.ps1
+++ b/SCEPman/Private/subscriptions.ps1
@@ -89,8 +89,8 @@ function GetSubscriptionDetails ([bool]$SearchAllSubscriptions, $SubscriptionId,
   return $potentialSubscription
 }
 
-function GetResourceGroup ($SCEPmanAppServiceName) {
-    $scWebAppsInTheSubscription = Invoke-Az -azCommand ('graph', 'query', '-q', "Resources | where type == 'microsoft.web/sites' and name =~ '$SCEPmanAppServiceName' | project name, resourceGroup") | Convert-LinesToObject
+function GetResourceGroup ($SCEPmanAppServiceName, $SubscriptionId) {
+    $scWebAppsInTheSubscription = Invoke-Az -azCommand ('graph', 'query', '--subscriptions', $SubscriptionId, '-q', "Resources | where type == 'microsoft.web/sites' and name =~ '$SCEPmanAppServiceName' | project name, resourceGroup") | Convert-LinesToObject
     if($null -ne $scWebAppsInTheSubscription -and $($scWebAppsInTheSubscription.count) -eq 1) {
         return $scWebAppsInTheSubscription.data[0].resourceGroup
     }
@@ -98,8 +98,8 @@ function GetResourceGroup ($SCEPmanAppServiceName) {
     throw "Unable to determine the resource group. This generally happens when a wrong name is entered for the SCEPman web app!"
 }
 
-function GetResourceGroupFromPlanName ($AppServicePlanName) {
-    $asplansInTheSubscription = Invoke-Az -azCommand ('graph', 'query', '-q', "Resources | where type == 'microsoft.web/serverfarms' and name =~ '$AppServicePlanName' | project name, resourceGroup") | Convert-LinesToObject
+function GetResourceGroupFromPlanName ($AppServicePlanName, $SubscriptionId) {
+    $asplansInTheSubscription = Invoke-Az -azCommand ('graph', 'query', '--subscriptions', $SubscriptionId, '-q', "Resources | where type == 'microsoft.web/serverfarms' and name =~ '$AppServicePlanName' | project name, resourceGroup") | Convert-LinesToObject
     if($null -ne $asplansInTheSubscription -and $($asplansInTheSubscription.count) -eq 1) {
         return $asplansInTheSubscription.data[0].resourceGroup
     }

--- a/SCEPman/Public/Complete-SCEPmanInstallation.ps1
+++ b/SCEPman/Public/Complete-SCEPmanInstallation.ps1
@@ -110,7 +110,7 @@ function Complete-SCEPmanInstallation
     Write-Information "Setting resource group"
     if ([String]::IsNullOrWhiteSpace($SCEPmanResourceGroup)) {
         # No resource group given, search for it now
-        $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName
+        $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $subscription.id
     }
 
     if ([String]::IsNullOrWhiteSpace($CertMasterResourceGroup)) {

--- a/SCEPman/Public/Complete-SCEPmanInstallation.ps1
+++ b/SCEPman/Public/Complete-SCEPmanInstallation.ps1
@@ -133,7 +133,7 @@ function Complete-SCEPmanInstallation
 
     if (-not $SkipCertificateMaster.IsPresent) {
         Write-Information "Getting Certificate Master web app"
-        $CertMasterAppServiceName = New-CertMasterAppService -TenantId $subscription.tenantId -SCEPmanAppServiceName $SCEPmanAppServiceName -SCEPmanResourceGroup $SCEPmanResourceGroup -CertMasterAppServiceName $CertMasterAppServiceName -CertMasterResourceGroup $CertMasterResourceGroup -DeploymentSlotName $DeploymentSlotName
+        $CertMasterAppServiceName = New-CertMasterAppService -TenantId $subscription.tenantId -SCEPmanAppServiceName $SCEPmanAppServiceName -SCEPmanResourceGroup $SCEPmanResourceGroup -CertMasterAppServiceName $CertMasterAppServiceName -CertMasterResourceGroup $CertMasterResourceGroup -DeploymentSlotName $DeploymentSlotName -SubscriptionId $subscription.id
 
         if ("Skipped" -eq $CertMasterAppServiceName) {
             $SkipCertificateMaster = $true
@@ -234,7 +234,7 @@ function Complete-SCEPmanInstallation
     }
 
     Write-Information "Adding permissions for SCEPman on the Key Vault"
-    $keyVault = FindConfiguredKeyVault -SCEPmanResourceGroup $SCEPmanResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName
+    $keyVault = FindConfiguredKeyVault -SCEPmanResourceGroup $SCEPmanResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $subscription.Id
     foreach ($scepmanServicePrincipal in $serviceprincipalOfScDeploymentSlots) {
         if ($PSCmdlet.ShouldProcess($keyVault.name, "Adding permissions for SCEPman on the Key Vault")) {
             AddSCEPmanPermissionsToKeyVault -KeyVault $keyVault -PrincipalId $scepmanServicePrincipal

--- a/SCEPman/Public/New-IntermediateCA.ps1
+++ b/SCEPman/Public/New-IntermediateCA.ps1
@@ -64,7 +64,7 @@ function New-IntermediateCA
   Write-Information "Setting resource group"
   if ([String]::IsNullOrWhiteSpace($SCEPmanResourceGroup)) {
       # No resource group given, search for it now
-      $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName
+      $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $subscription.id
       Write-Information "Found resource group $SCEPmanResourceGroup"
   }
 

--- a/SCEPman/Public/New-SCEPmanClone.ps1
+++ b/SCEPman/Public/New-SCEPmanClone.ps1
@@ -75,7 +75,7 @@ function New-SCEPmanClone
     Write-Information "Setting source resource group"
     if ([String]::IsNullOrWhiteSpace($SourceResourceGroup)) {
         # No resource group given, search for it now
-        $SourceResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SourceAppServiceName
+        $SourceResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SourceAppServiceName -SubscriptionId $sourceSubscription.id
     }
 
     Write-Information "Checking VNET integration of SCEPman"
@@ -107,7 +107,7 @@ function New-SCEPmanClone
 
     Write-Information "Searching for target App Service Plan"
     if ([String]::IsNullOrWhiteSpace($TargetResourceGroup)) {
-        $TargetResourceGroup = GetResourceGroupFromPlanName -AppServicePlanName $TargetAppServicePlan
+        $TargetResourceGroup = GetResourceGroupFromPlanName -AppServicePlanName $TargetAppServicePlan -SubscriptionId $targetSubscription.id
         Write-Information "Using Resource Group $TargetResourceGroup (same as app service plan $TargetAppServicePlan)"
     }
     $trgtAsp = GetAppServicePlan -AppServicePlanName $TargetAppServicePlan -ResourceGroup $TargetResourceGroup -SubscriptionId $targetSubscription.Id

--- a/SCEPman/Public/New-SCEPmanClone.ps1
+++ b/SCEPman/Public/New-SCEPmanClone.ps1
@@ -92,13 +92,13 @@ function New-SCEPmanClone
     $storageAccountTableEndpoint = $existingTableStorageEndpointSetting.Trim('"')
     if(-not [string]::IsNullOrEmpty($storageAccountTableEndpoint)) {
         Write-Verbose "Storage Account Table Endpoint $storageAccountTableEndpoint found"
-        $ScStorageAccount = GetExistingStorageAccount -dataTableEndpoint $storageAccountTableEndpoint
+        $ScStorageAccount = GetExistingStorageAccount -dataTableEndpoint $storageAccountTableEndpoint -SubscriptionId $sourceSubscription.Id
     } else {
         Write-Warning "No Storage Account found. Not adding any permissions."
     }
 
     Write-Information "Reading Key Vault registration from source"
-    $keyvault = FindConfiguredKeyVault -SCEPmanAppServiceName $SourceAppServiceName -SCEPmanResourceGroup $SourceResourceGroup
+    $keyvault = FindConfiguredKeyVault -SCEPmanAppServiceName $SourceAppServiceName -SCEPmanResourceGroup $SourceResourceGroup -SubscriptionId $sourceSubscription.Id
     Write-Verbose "Key Vault $($keyvault.name) identified"
 
     Write-Information "Getting target subscription details"
@@ -137,7 +137,7 @@ function New-SCEPmanClone
         $DcrId = $SCEPmanSourceSettings.settings | Where-Object name -match 'AppConfig(:|__)LoggingConfig(:|__)RuleId' | Select-Object -ExpandProperty value
         if ($DcrId) {
             Write-Information "Found configured data collection rule. Confirm resource and add permission."
-            $DataCollectionRule = GetDataCollectionRule -DcrId $DcrId
+            $DataCollectionRule = GetDataCollectionRule -DcrId $DcrId -SubscriptionId $sourceSubscription.Id
 
             AddAppRoleAssignmentsForLogIngestionAPI -DcrResourceId $DataCollectionRule.id -ServicePrincipal $serviceprincipalsc.principalId
         }

--- a/SCEPman/Public/New-SCEPmanDeploymentSlot.ps1
+++ b/SCEPman/Public/New-SCEPmanDeploymentSlot.ps1
@@ -100,7 +100,7 @@ function New-SCEPmanDeploymentSlot
         $storageAccountTableEndpoint = $existingTableStorageEndpointSetting.Trim('"')
         if(-not [string]::IsNullOrEmpty($storageAccountTableEndpoint)) {
         Write-Verbose "Storage Account Table Endpoint $storageAccountTableEndpoint found"
-        $ScStorageAccount = GetExistingStorageAccount -dataTableEndpoint $storageAccountTableEndpoint
+        $ScStorageAccount = GetExistingStorageAccount -dataTableEndpoint $storageAccountTableEndpoint -SubscriptionId $subscription.Id
         SetStorageAccountPermissions -SubscriptionId $subscription.Id -ScStorageAccount $ScStorageAccount -servicePrincipals $servicePrincipals
         } else {
             Write-Warning "No Storage Account found. Not adding any permissions."
@@ -108,7 +108,7 @@ function New-SCEPmanDeploymentSlot
     }
 
     Write-Information "Adding permissions to Key Vault"
-    $keyvault = FindConfiguredKeyVault -SCEPmanAppServiceName $SCEPmanAppServiceName -SCEPmanResourceGroup $SCEPmanResourceGroup
+    $keyvault = FindConfiguredKeyVault -SCEPmanAppServiceName $SCEPmanAppServiceName -SCEPmanResourceGroup $SCEPmanResourceGroup -SubscriptionId $subscription.Id
     Write-Verbose "Key Vault $keyvaultname identified"
     if ($PSCmdlet.ShouldProcess($keyvault.name, "Adding key vault permissions to new deployment slot")) {
         AddSCEPmanPermissionsToKeyVault -KeyVault $keyvault -PrincipalId $serviceprincipalsc.principalId

--- a/SCEPman/Public/New-SCEPmanDeploymentSlot.ps1
+++ b/SCEPman/Public/New-SCEPmanDeploymentSlot.ps1
@@ -109,7 +109,7 @@ function New-SCEPmanDeploymentSlot
 
     Write-Information "Adding permissions to Key Vault"
     $keyvault = FindConfiguredKeyVault -SCEPmanAppServiceName $SCEPmanAppServiceName -SCEPmanResourceGroup $SCEPmanResourceGroup -SubscriptionId $subscription.Id
-    Write-Verbose "Key Vault $keyvaultname identified"
+    Write-Verbose "Key Vault $($keyvault.name) identified"
     if ($PSCmdlet.ShouldProcess($keyvault.name, "Adding key vault permissions to new deployment slot")) {
         AddSCEPmanPermissionsToKeyVault -KeyVault $keyvault -PrincipalId $serviceprincipalsc.principalId
     }

--- a/SCEPman/Public/New-SCEPmanDeploymentSlot.ps1
+++ b/SCEPman/Public/New-SCEPmanDeploymentSlot.ps1
@@ -61,7 +61,7 @@ function New-SCEPmanDeploymentSlot
     Write-Information "Setting resource group"
     if ([String]::IsNullOrWhiteSpace($SCEPmanResourceGroup)) {
         # No resource group given, search for it now
-        $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName
+        $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $subscription.id
     }
 
     Write-Information "Getting existing SCEPman deployment slots"

--- a/SCEPman/Public/Set-SCEPmanEndpoint.ps1
+++ b/SCEPman/Public/Set-SCEPmanEndpoint.ps1
@@ -49,13 +49,13 @@ Function Set-SCEPmanEndpoint {
         Write-Information "Subscription is set to $($subscription.name)"
 
         Write-Information "Setting resource group"
-        if ([String]::IsNullOrWhiteSpace($SCEPmanResourceGroup)) {
+        if ([String]::IsNullOrWhiteSpace($SCEPmanResourceGroupName)) {
             # No resource group given, search for it now
-            $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $subscription.id
+            $SCEPmanResourceGroupName = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $subscription.id
         }
 
         Write-Information "Getting SCEPman deployment slots"
-        [array]$deploymentSlotsSc = GetDeploymentSlots -appServiceName $SCEPmanAppServiceName -resourceGroup $SCEPmanResourceGroup
+        [array]$deploymentSlotsSc = GetDeploymentSlots -appServiceName $SCEPmanAppServiceName -resourceGroup $SCEPmanResourceGroupName
         Write-Information "$($deploymentSlotsSc.Count) deployment slots found"
 
         if ($DeploymentSlotName) {
@@ -88,7 +88,7 @@ Function Set-SCEPmanEndpoint {
 
         $SetAppSettingsParameters = @{
             AppServiceName = $SCEPmanAppServiceName
-            resourceGroup  = $SCEPmanResourceGroup
+            resourceGroup  = $SCEPmanResourceGroupName
             Settings       = $EndpointSettings
         }
 

--- a/SCEPman/Public/Set-SCEPmanEndpoint.ps1
+++ b/SCEPman/Public/Set-SCEPmanEndpoint.ps1
@@ -51,7 +51,7 @@ Function Set-SCEPmanEndpoint {
         Write-Information "Setting resource group"
         if ([String]::IsNullOrWhiteSpace($SCEPmanResourceGroup)) {
             # No resource group given, search for it now
-            $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName
+            $SCEPmanResourceGroup = GetResourceGroup -SCEPmanAppServiceName $SCEPmanAppServiceName -SubscriptionId $subscription.id
         }
 
         Write-Information "Getting SCEPman deployment slots"

--- a/SCEPman/Public/Sync-IntuneCertificate.ps1
+++ b/SCEPman/Public/Sync-IntuneCertificate.ps1
@@ -46,7 +46,7 @@ function Sync-IntuneCertificate
     Write-Information "Setting resource group"
     if ([String]::IsNullOrWhiteSpace($CertMasterResourceGroup)) {
         # No resource group given, search for it now
-        $CertMasterResourceGroup = GetResourceGroup -SCEPmanAppServiceName $CertMasterAppServiceName
+        $CertMasterResourceGroup = GetResourceGroup -SCEPmanAppServiceName $CertMasterAppServiceName -SubscriptionId $subscription.id
     }
 
     Write-Information "Finding API endpoint of Certificate Master"

--- a/Tests/New-SCEPmanClone.Tests.ps1
+++ b/Tests/New-SCEPmanClone.Tests.ps1
@@ -117,7 +117,7 @@ Describe 'SCEPman Clone' {
                     # Some more are returned in reality
                 }
             } -ParameterFilter { $dataTableEndpoint -eq "storage-account-endpoint" }
-            function FindConfiguredKeyVault ($SCEPmanResourceGroup, $SCEPmanAppServiceName) {} # Mocked
+            function FindConfiguredKeyVault ($SCEPmanResourceGroup, $SCEPmanAppServiceName, $SubscriptionId) {} # Mocked
             Mock FindConfiguredKeyVault {
                 return @{
                     name = "test-kv-name"

--- a/Tests/app-service.Tests.ps1
+++ b/Tests/app-service.Tests.ps1
@@ -104,7 +104,7 @@ Describe 'App Service' {
                                 }
                             }
                         }"
-            } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix 'graph query -q "Resources' -azCommandMidfix "'as-scepman'"}
+            } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix 'graph query --subscriptions' -azCommandMidfix "'as-scepman'"}
         }
 
         BeforeEach {
@@ -115,7 +115,7 @@ Describe 'App Service' {
             Mock az { return 'app' } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix 'webapp show' -azCommandSuffix '--output tsv' -azCommandMidfix "--query kind" }
             Mock GetCertMasterAppServiceName { return "as-scepman-cm" }
 
-            $certMaster = New-CertMasterAppService -SCEPmanResourceGroup "rg-scepman-test" -SCEPmanAppServiceName "as-scepman" -CertMasterResourceGroup "rg-certmaster" -TenantId "00000000-0000-1234-0000-000000000000"
+            $certMaster = New-CertMasterAppService -SCEPmanResourceGroup "rg-scepman-test" -SCEPmanAppServiceName "as-scepman" -CertMasterResourceGroup "rg-certmaster" -TenantId "00000000-0000-1234-0000-000000000000" -SubscriptionId "00000000-0000-0000-0000-000000000000"
 
             $certMaster | Should -Be "as-scepman-cm"
         }
@@ -132,7 +132,7 @@ Describe 'App Service' {
             Mock az { return $null } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix 'webapp config set' -azCommandMidfix "--name as-scepman-cm" }
 
             # Act
-            $certMaster = New-CertMasterAppService -SCEPmanResourceGroup "rg-scepman-test" -SCEPmanAppServiceName "as-scepman" -CertMasterResourceGroup "rg-certmaster" -TenantId "00000000-0000-1234-0000-000000000000"
+            $certMaster = New-CertMasterAppService -SCEPmanResourceGroup "rg-scepman-test" -SCEPmanAppServiceName "as-scepman" -CertMasterResourceGroup "rg-certmaster" -TenantId "00000000-0000-1234-0000-000000000000" -SubscriptionId "00000000-0000-0000-0000-000000000000"
 
             # Assert
             $certMaster | Should -Be "as-scepman-cm"

--- a/Tests/key-vault.Tests.ps1
+++ b/Tests/key-vault.Tests.ps1
@@ -150,10 +150,10 @@ Describe 'Key Vault' {
                 'skip_token': null,
                 'total_records': 1
             }"
-        } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix "graph query" -azCommandMidfix "Resources | where type == 'microsoft.keyvault/vaults'" }
+        } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix "graph query --subscriptions" -azCommandMidfix "Resources | where type == 'microsoft.keyvault/vaults'" }
 
         # Act
-        $keyVault = FindConfiguredKeyVault -SCEPmanResourceGroup "test-rg" -SCEPmanAppServiceName "test-app-service"
+        $keyVault = FindConfiguredKeyVault -SCEPmanResourceGroup "test-rg" -SCEPmanAppServiceName "test-app-service" -SubscriptionId "83804974-c230-4240-b384-0c4d3b7ef201"
 
         # Assert
         $keyVault.name | Should -Be $keyVaultName

--- a/Tests/log-analytics.Tests.ps1
+++ b/Tests/log-analytics.Tests.ps1
@@ -37,20 +37,24 @@ Describe 'Log Analytics' {
         } -ParameterFilter {
             $azCommand[0] -eq 'graph' -and
             $azCommand[1] -eq 'query' -and
-            $azCommand[3].Contains("resourceGroup == 'rg-scepman'")
+            $azCommand[2] -eq '--subscriptions' -and
+            $azCommand[3] -eq 'sub-1' -and
+            $azCommand[5].Contains("resourceGroup == 'rg-scepman'")
         }
         Mock Read-Host {
             return 'law-shared'
         } -ParameterFilter { ($Prompt -join '') -like '*more than one existing log analytics workspace*' }
 
-        $workspace = GetLogAnalyticsWorkspace -ResourceGroup 'rg-scepman'
+        $workspace = GetLogAnalyticsWorkspace -ResourceGroup 'rg-scepman' -SubscriptionId 'sub-1'
 
         $workspace.name | Should -Be 'law-shared'
         $workspace.workspaceId | Should -Be '22222222-2222-2222-2222-222222222222'
         Should -Invoke Invoke-Az -Exactly 1 -ParameterFilter {
             $azCommand[0] -eq 'graph' -and
             $azCommand[1] -eq 'query' -and
-            $azCommand[3].Contains("resourceGroup == 'rg-scepman'")
+            $azCommand[2] -eq '--subscriptions' -and
+            $azCommand[3] -eq 'sub-1' -and
+            $azCommand[5].Contains("resourceGroup == 'rg-scepman'")
         }
     }
 

--- a/Tests/storage-account.Tests.ps1
+++ b/Tests/storage-account.Tests.ps1
@@ -30,7 +30,7 @@ $jsonOfStorageAccount
 ""skip_token"": null,
 ""total_records"": 1
 }"
-     } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix 'graph query' }
+     } -ParameterFilter { CheckAzParameters -argsFromCommand $args -azCommandPrefix 'graph query --subscriptions' }
     EnsureNoAdditionalAzCalls
     function CheckReturnedStorageAccountMatchesTestValue ($storageAccount) {
       $storageAccount.location | Should -Be "germanywestcentral"
@@ -48,7 +48,7 @@ $jsonOfStorageAccount
 
   It 'Finds an existing Storage Account' {
     # Act
-    $staccount = GetExistingStorageAccount -dataTableEndpoint 'https://stgxyztest.table.core.windows.net/'
+    $staccount = GetExistingStorageAccount -dataTableEndpoint 'https://stgxyztest.table.core.windows.net/' -SubscriptionId '63ee67fb-aad6-4711-82a9-ff838a489299'
 
     # Assert
     CheckReturnedStorageAccountMatchesTestValue -StorageAccount $staccount
@@ -61,7 +61,7 @@ $jsonOfStorageAccount
     mock Read-Host { return "stgxyztest" } -ParameterFilter { ($Prompt -join '').Contains("enter the name of the storage account") }
 
     # Act
-    $staccount = VerifyStorageAccountDoesNotExist -dataTableEndpoint 'https://stgxyztest.table.core.windows.net/'
+    $staccount = VerifyStorageAccountDoesNotExist -ResourceGroup 'rg-xyz-test' -SubscriptionId '63ee67fb-aad6-4711-82a9-ff838a489299'
 
     # Assert
     CheckReturnedStorageAccountMatchesTestValue -StorageAccount $staccount
@@ -74,7 +74,7 @@ $jsonOfStorageAccount
     mock Read-Host { return "" } -ParameterFilter { ($Prompt -join '').Contains("want to create a new storage account") }
 
     # Act
-    $staccount = VerifyStorageAccountDoesNotExist -dataTableEndpoint 'https://stgxyztest.table.core.windows.net/'
+    $staccount = VerifyStorageAccountDoesNotExist -ResourceGroup 'rg-xyz-test' -SubscriptionId '63ee67fb-aad6-4711-82a9-ff838a489299'
 
     # Assert
     $staccount | Should -Be $null

--- a/Tests/subscriptions.Tests.ps1
+++ b/Tests/subscriptions.Tests.ps1
@@ -166,3 +166,73 @@ Describe 'GetSubscriptionDetails' {
     # TODO: how to simulate user input inline??
     # Write-Output 1 | GetSubscriptionDetails
 }
+
+Describe 'GetResourceGroup' {
+    BeforeAll {
+        $singleWebAppResult = '{
+            "count": 1,
+            "data": [ { "name": "as-scepman", "resourceGroup": "rg-scepman" } ],
+            "skip_token": null,
+            "total_records": 1
+        }'
+    }
+
+    It 'Returns the resource group and scopes the graph query to the subscription' {
+        Mock Invoke-Az {
+            return $singleWebAppResult
+        } -ParameterFilter { $azCommand[0] -eq 'graph' -and $azCommand[1] -eq 'query' }
+
+        $resourceGroup = GetResourceGroup -SCEPmanAppServiceName 'as-scepman' -SubscriptionId 'sub-1'
+
+        $resourceGroup | Should -Be 'rg-scepman'
+        Should -Invoke Invoke-Az -Exactly 1 -ParameterFilter {
+            $azCommand[0] -eq 'graph' -and
+            $azCommand[1] -eq 'query' -and
+            $azCommand -contains '--subscriptions' -and
+            $azCommand -contains 'sub-1'
+        }
+    }
+
+    It 'Throws when the resource group cannot be uniquely determined' {
+        Mock Invoke-Az {
+            return '{ "count": 0, "data": [], "skip_token": null, "total_records": 0 }'
+        } -ParameterFilter { $azCommand[0] -eq 'graph' -and $azCommand[1] -eq 'query' }
+
+        { GetResourceGroup -SCEPmanAppServiceName 'as-scepman' -SubscriptionId 'sub-1' 2>$null } | Should -Throw
+    }
+}
+
+Describe 'GetResourceGroupFromPlanName' {
+    BeforeAll {
+        $singlePlanResult = '{
+            "count": 1,
+            "data": [ { "name": "asp-scepman", "resourceGroup": "rg-scepman" } ],
+            "skip_token": null,
+            "total_records": 1
+        }'
+    }
+
+    It 'Returns the resource group and scopes the graph query to the subscription' {
+        Mock Invoke-Az {
+            return $singlePlanResult
+        } -ParameterFilter { $azCommand[0] -eq 'graph' -and $azCommand[1] -eq 'query' }
+
+        $resourceGroup = GetResourceGroupFromPlanName -AppServicePlanName 'asp-scepman' -SubscriptionId 'sub-1'
+
+        $resourceGroup | Should -Be 'rg-scepman'
+        Should -Invoke Invoke-Az -Exactly 1 -ParameterFilter {
+            $azCommand[0] -eq 'graph' -and
+            $azCommand[1] -eq 'query' -and
+            $azCommand -contains '--subscriptions' -and
+            $azCommand -contains 'sub-1'
+        }
+    }
+
+    It 'Throws when the resource group cannot be uniquely determined' {
+        Mock Invoke-Az {
+            return '{ "count": 0, "data": [], "skip_token": null, "total_records": 0 }'
+        } -ParameterFilter { $azCommand[0] -eq 'graph' -and $azCommand[1] -eq 'query' }
+
+        { GetResourceGroupFromPlanName -AppServicePlanName 'asp-scepman' -SubscriptionId 'sub-1' 2>$null } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Why
Availability of more than 1000 subscriptions will cause Graph queries to only return results for the first 1000. This causes resources to not be found at different occasions.

## What changed

Every graph query that runs *after* the target subscription is known is now scoped with
`--subscriptions <id>`:

- Added a `$SubscriptionId` parameter to the affected private functions
  (`app-service.ps1`, `key-vault.ps1`, `log-analytics.ps1`, `storage-account.ps1`,
  and `GetResourceGroup` / `GetResourceGroupFromPlanName` in `subscriptions.ps1`).
- Threaded the already-resolved subscription id through from every public entry point
  (`Complete-SCEPmanInstallation`, `New-SCEPmanClone`, `New-SCEPmanDeploymentSlot`,
  `New-IntermediateCA`, `Set-SCEPmanEndpoint`, `Sync-IntuneCertificate`). The clone uses
  the source vs. target subscription as appropriate.

## Out of scope

The two intentional "search-all-subscriptions" discovery queries (`Get-SubscriptionDetailsUsingAppName`,
`Get-SubscriptionDetailsUsingPlanName`) and the `az account list` enumeration remain untouched as they run *before* a subscription is known in the case no subscription is passed.